### PR TITLE
Fix for undefined reference to `SDL_PumpEvents'

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -96,7 +96,7 @@ OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -D_GNU_SOURCE=1
 LDFLAGS += $(SHARED)
-LDLIBS += -lm
+LDLIBS += -lm -lSDL2
 
 # Since we are building a shared library, we must compile with -fPIC on some architectures
 # On 32-bit x86 systems we do not want to use -fPIC because we don't have to and it has a big performance penalty on this arch


### PR DESCRIPTION
Fixes https://github.com/raphnet/mupen64plus-input-raphnetraw/issues/8

Alternatively, mupen64plus-core was recently fixed:

https://github.com/mupen64plus/mupen64plus-core/commit/13d1ad4aa2e03297b67bca16a79a42b4c7c715d3

So SDL_PumpEvents could be removed altogether