### PR TITLE
Remove SDL_PumpEvents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 *.o
 *.swp
+/projects/unix/_obj*/

--- a/projects/unix/buildwin32.sh
+++ b/projects/unix/buildwin32.sh
@@ -5,7 +5,7 @@ UNAME=MINGW32
 DESTDIR=./dist_win32
 
 HID_CFLAGS="-I $HIDHOME/hidapi"
-HID_LDLIBS="-L $HIDHOME/windows/.libs/ -lhidapi sdl.lib"
+HID_LDLIBS="-L $HIDHOME/windows/.libs/ -lhidapi"
 TARGETS=all
 MAKEFILE=Makefile
 
@@ -13,10 +13,6 @@ make -f $MAKEFILE clean
 if [ $? -ne 0 ]; then
 	exit 1
 fi
-
-# Hack to let this project link without requiring libsdl. Without
-# this linking will fail due to a missing symbol (SDL_PumpEvents)
-i686-w64-mingw32-dlltool -d sdl.def -l sdl.lib
 
 make -f $MAKEFILE CROSS_COMPILE=i686-w64-mingw32- UNAME=$UNAME HID_CFLAGS="$HID_CFLAGS" HID_LDLIBS="$HID_LDLIBS" $TARGETS V=1
 if [ $? -ne 0 ]; then

--- a/projects/unix/buildwin64.sh
+++ b/projects/unix/buildwin64.sh
@@ -5,7 +5,7 @@ UNAME=MINGW64
 DESTDIR=./dist_win64
 
 HID_CFLAGS="-I $HIDHOME/hidapi"
-HID_LDLIBS="-L $HIDHOME/windows/.libs/ -lhidapi sdl.lib"
+HID_LDLIBS="-L $HIDHOME/windows/.libs/ -lhidapi"
 TARGETS=all
 MAKEFILE=Makefile
 
@@ -13,10 +13,6 @@ make -f $MAKEFILE clean
 if [ $? -ne 0 ]; then
 	exit 1
 fi
-
-# Hack to let this project link without requiring libsdl. Without
-# this linking will fail due to a missing symbol (SDL_PumpEvents)
-x86_64-w64-mingw32-dlltool -d sdl.def -l sdl.lib
 
 make -f $MAKEFILE CROSS_COMPILE=x86_64-w64-mingw32- UNAME=$UNAME HID_CFLAGS="$HID_CFLAGS" HID_LDLIBS="$HID_LDLIBS" $TARGETS V=1
 if [ $? -ne 0 ]; then

--- a/projects/unix/sdl.def
+++ b/projects/unix/sdl.def
@@ -1,3 +1,0 @@
-LIBRARY SDL.dll
-EXPORTS
-SDL_PumpEvents

--- a/src/plugin_front.c
+++ b/src/plugin_front.c
@@ -293,20 +293,8 @@ EXPORT void CALL ControllerCommand(int Control, unsigned char *Command)
 	pb_controllerCommand(EMU_2_ADAP_PORT(Control), Command);
 }
 
-#if PLUGIN_VERSION >= 0x010002
-void SDL_PumpEvents(void);
-#endif
-
 EXPORT void CALL GetKeys( int Control, BUTTONS *Keys )
 {
-	/* Since March 23, 2018, the SDL_PumpEvents() is supposed to be called
-	   by the input plugin. Even though this plugin has nothing to do with
-	   SDL, it must now call SDL_PumpEvents. Otherwise non-input events
-	   such as SDL_QUIT (which occur when one tries to close the window)
-	   are never emitted! */
-#if PLUGIN_VERSION >= 0x010002
-	SDL_PumpEvents();
-#endif
 }
 
 EXPORT void CALL RomClosed(void)


### PR DESCRIPTION
This is an alternative to #10.

mupen64plus-core was recently fixed:

mupen64plus/mupen64plus-core@13d1ad4

So SDL_PumpEvents can be removed altogether