### PR TITLE
build: don't hard-code pkg-config

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -137,6 +137,14 @@ ifeq ($(OS), OSX)
   endif
 endif
 
+# test for essential build dependencies
+ifeq ($(origin PKG_CONFIG), undefined)
+  PKG_CONFIG = $(CROSS_COMPILE)pkg-config
+  ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null),)
+    $(error $(PKG_CONFIG) not found)
+  endif
+endif
+
 ifeq ($(OS), LINUX)
     HIDAPI_NAME=hidapi-hidraw
 else
@@ -145,17 +153,11 @@ endif
 
 # test for presence of HIDLIB
 ifeq ($(origin HID_CFLAGS) $(origin HID_LDLIBS), undefined undefined)
-  HIDAPI_CONFIG = $(CROSS_COMPILE)pkg-config $(HIDAPI_NAME)
-  ifeq ($(shell which $(HIDAPI_CONFIG) 2>/dev/null),)
-    HIDAPI_CONFIG = $(CROSS_COMPILE)pkg-config $(HIDAPI_NAME)
-    ifeq ($(shell which $(HIDAPI_CONFIG) 2>/dev/null),)
-      $(error No HIDAPI development libraries found!)
-    else
-      $(warning Using HIDAPI libraries)
-    endif
+  ifeq ($(shell $(PKG_CONFIG) --modversion $(HIDAPI_NAME) 2>/dev/null),)
+    $(error No HIDAPI development libraries found!)
   endif
-  HID_CFLAGS  += $(shell $(HIDAPI_CONFIG) --cflags)
-  HID_LDLIBS += $(shell $(HIDAPI_CONFIG) --libs)
+  HID_CFLAGS = $(shell $(PKG_CONFIG) --cflags $(HIDAPI_NAME))
+  HID_LDLIBS = $(shell $(PKG_CONFIG) --libs $(HIDAPI_NAME))
 endif
 CFLAGS += $(HID_CFLAGS)
 LDLIBS += $(HID_LDLIBS)


### PR DESCRIPTION
This is useful for distros that set `PKG_CONFIG` in the environment. The check was copied from `mupen64plus-core`.